### PR TITLE
Fixed date format to use 24 hours clock instead of 12.

### DIFF
--- a/video/video_mapper.go
+++ b/video/video_mapper.go
@@ -23,7 +23,7 @@ const (
 	videoContentURIBase = "http://next-video-mapper.svc.ft.com/video/model/"
 	videoAuthority      = "http://api.ft.com/system/NEXT-VIDEO-EDITOR"
 	ftBrandID           = "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
-	dateFormat          = "2006-01-02T03:04:05.000Z0700"
+	dateFormat          = "2006-01-02T15:04:05.000Z0700"
 	defaultAccessLevel  = "free"
 	uuidGenerationSalt  = "storypackage"
 )


### PR DESCRIPTION
Merging this fix into the kafka topic check one to release them together.
Supersedes https://github.com/Financial-Times/upp-next-video-mapper/pull/8