### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/helm/upp-next-video-mapper/templates/service.yaml
+++ b/helm/upp-next-video-mapper/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/upp-next-video-mapper/values.yaml
+++ b/helm/upp-next-video-mapper/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/upp-next-video-mapper

--- a/video/healthcheck.go
+++ b/video/healthcheck.go
@@ -40,7 +40,7 @@ func (h *HealthCheck) readQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "read-message-queue-proxy-reachable",
 		Name:             "Read Message Queue Proxy Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Publishing or updating videos will not be possible, clients will not see the new content.",
 		TechnicalSummary: "Read message queue proxy is not reachable/healthy",
 		PanicGuide:       "https://dewey.ft.com/up-vm.html",
@@ -52,7 +52,7 @@ func (h *HealthCheck) writeQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "write-message-queue-proxy-reachable",
 		Name:             "Write Message Queue Proxy Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Publishing or updating videos will not be possible, clients will not see the new content.",
 		TechnicalSummary: "Write message queue proxy is not reachable/healthy",
 		PanicGuide:       "https://dewey.ft.com/up-vm.html",


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red