### PR TITLE
Feature/uppsf 1994 delete payload changes

### DIFF
--- a/video/video_mapper.go
+++ b/video/video_mapper.go
@@ -49,7 +49,7 @@ func (v VideoMapper) TransformMsg(m consumer.Message) (msg producer.Message, uui
 
 	var videoContent map[string]interface{}
 	if err := json.Unmarshal([]byte(m.Body), &videoContent); err != nil {
-		return producer.Message{}, "", fmt.Errorf("Error: %v - Video JSON couldn't be unmarshalled. Skipping invalid JSON: %v", err.Error(), m.Body)
+		return producer.Message{}, "", fmt.Errorf("error: %v - Video JSON couldn't be unmarshalled. Skipping invalid JSON: %v", err.Error(), m.Body)
 	}
 
 	isPublishEvent := isPublishEvent(videoContent)
@@ -58,7 +58,7 @@ func (v VideoMapper) TransformMsg(m consumer.Message) (msg producer.Message, uui
 	if !isPublishEvent {
 		uuid, err = get("uuid", videoContent)
 		if err != nil {
-			return producer.Message{}, "", fmt.Errorf("Error: %v - Could not extract UUID from video message. Skipping invalid JSON: %v", err.Error(), m.Body)
+			return producer.Message{}, "", fmt.Errorf("error: %v - Could not extract UUID from video message. Skipping invalid JSON: %v", err.Error(), m.Body)
 		}
 
 		contentURI := getPrefixedUrl(videoContentURIBase, uuid)
@@ -69,7 +69,7 @@ func (v VideoMapper) TransformMsg(m consumer.Message) (msg producer.Message, uui
 
 	uuid, err = get("id", videoContent)
 	if err != nil {
-		return producer.Message{}, "", fmt.Errorf("Error: %v - Could not extract UUID from video message. Skipping invalid JSON: %v", err.Error(), m.Body)
+		return producer.Message{}, "", fmt.Errorf("error: %v - Could not extract UUID from video message. Skipping invalid JSON: %v", err.Error(), m.Body)
 	}
 
 	contentURI := getPrefixedUrl(videoContentURIBase, uuid)

--- a/video/video_mapper_test.go
+++ b/video/video_mapper_test.go
@@ -101,7 +101,7 @@ func TestTransformMsg_UnpublishEvent(t *testing.T) {
 					"lastModified": "2017-04-04T14:42:58.920Z",
 					"publishReference": "tid_123123",
 					"type": "video",
-					"id": "bad50c54-76d9-30e9-8734-b999c708aa4c"}`,
+					"uuid": "bad50c54-76d9-30e9-8734-b999c708aa4c"}`,
 	}
 
 	resultMsg, uuid, err := mapper.TransformMsg(message)


### PR DESCRIPTION
# Description

## What

The mapper now expects that the payload contains an `uuid` attribute instead of an `id` attribute.  

## Why

In order for the `cm-content-deleter` to be able to use `upp-content-validation-kit` it must receive `uuid` in the payload, therefore we modified the `cms-notifier` to send it in the payload, hence, the mapper needs to change as well so that it recognizes the payload as valid.

## Anything else
I had to decapitalize some error messages in order to fix linting errors.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
