### PR TITLE
Replace deprecated UUID library with another one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,11 @@ require (
 	github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d
 	github.com/Financial-Times/transactionid-utils-go v0.1.0
 	github.com/Financial-Times/uuid-utils-go v0.0.0-20170512090827-6a93dec4ed96
+	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.3.0
 	github.com/hashicorp/go-version v0.0.0-20170202080759-03c5bf6be031 // indirect
 	github.com/jawher/mow.cli v0.0.0-20161123225447-0de3d3b4ed00
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
-	github.com/satori/go.uuid v1.1.1-0.20160927100844-b061729afc07
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	github.com/willf/bitset v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d
 	github.com/Financial-Times/transactionid-utils-go v0.1.0
 	github.com/Financial-Times/uuid-utils-go v0.0.0-20170512090827-6a93dec4ed96
-	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.3.0
 	github.com/hashicorp/go-version v0.0.0-20170202080759-03c5bf6be031 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,9 +12,10 @@ github.com/Financial-Times/transactionid-utils-go v0.1.0 h1:CYFWsSwsVcuXZfkpVhhK
 github.com/Financial-Times/transactionid-utils-go v0.1.0/go.mod h1:tPAcAFs/dR6Q7hBDGNyUyixHRvg/n9NW/JTq8C58oZ0=
 github.com/Financial-Times/uuid-utils-go v0.0.0-20170512090827-6a93dec4ed96 h1:IqE0/T6uiou5evmtF0DRYktHSArO5xAzTvW+ToMzhO8=
 github.com/Financial-Times/uuid-utils-go v0.0.0-20170512090827-6a93dec4ed96/go.mod h1:i62wLwNq+NmRCQpZS5BLTKsOVYsTOxs9bSx7FgtxXwM=
-github.com/davecgh/go-spew v1.0.1-0.20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
+github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.3.0 h1:HwSEKGN6U5T2aAQTfu5pW8fiwjSp3IgwdRbkICydk/c=
@@ -25,15 +26,11 @@ github.com/jawher/mow.cli v0.0.0-20161123225447-0de3d3b4ed00 h1:zw1RZxExGkfi1xKS
 github.com/jawher/mow.cli v0.0.0-20161123225447-0de3d3b4ed00/go.mod h1:5hQj2V8g+qYmLUVWqu4Wuja1pI57M83EChYLVZ0sMKk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/satori/go.uuid v1.1.1-0.20160927100844-b061729afc07 h1:0OTA2rHAnTd0zaCoNmm7Mu0QYd5IoRIMfTILRPeu8mo=
-github.com/satori/go.uuid v1.1.1-0.20160927100844-b061729afc07/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.1.5-0.20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/willf/bitset v1.1.2 h1:qRQzojujJ9p4JrdmSxeu3hn348shKWovBYAQth9NoTg=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Financial-Times/uuid-utils-go v0.0.0-20170512090827-6a93dec4ed96 h1:I
 github.com/Financial-Times/uuid-utils-go v0.0.0-20170512090827-6a93dec4ed96/go.mod h1:i62wLwNq+NmRCQpZS5BLTKsOVYsTOxs9bSx7FgtxXwM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
-github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.3.0 h1:HwSEKGN6U5T2aAQTfu5pW8fiwjSp3IgwdRbkICydk/c=

--- a/video/video_mapper.go
+++ b/video/video_mapper.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Financial-Times/message-queue-go-producer/producer"
 	"github.com/Financial-Times/message-queue-gonsumer/consumer"
 	uuidUtils "github.com/Financial-Times/uuid-utils-go"
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 
 	"github.com/Financial-Times/go-logger"
 )
@@ -186,7 +186,7 @@ func getMainImage(videoContent map[string]interface{}, videoUUID, tid string) (s
 
 	imageUUIDString, err := getUUIDFromURI(imageURI)
 	if err != nil {
-		_, parsingErr := uuid.FromString(imageURI)
+		_, parsingErr := uuid.Parse(imageURI)
 		if parsingErr != nil {
 			// The provided string is neither URI nor UUID.
 			return "", err
@@ -347,16 +347,10 @@ func buildAndMarshalPublicationEvent(p *videoPayload, contentURI, lastModified, 
 		return producer.Message{}, err
 	}
 
-	uuid, err := uuid.NewV4()
-	if err != nil {
-		logger.WithError(err).Warn("Failed to generate UUID")
-		return producer.Message{}, err
-	}
-
 	headers := map[string]string{
 		"X-Request-Id":      pubRef,
 		"Message-Timestamp": lastModified,
-		"Message-Id":        uuid.String(),
+		"Message-Id":        uuid.New().String(),
 		"Message-Type":      "cms-content-published",
 		"Content-Type":      "application/json",
 		"Origin-System-Id":  videoSystemOrigin,

--- a/video/video_mapper.go
+++ b/video/video_mapper.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Financial-Times/message-queue-go-producer/producer"
 	"github.com/Financial-Times/message-queue-gonsumer/consumer"
 	uuidUtils "github.com/Financial-Times/uuid-utils-go"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 
 	"github.com/Financial-Times/go-logger"
 )
@@ -347,10 +347,16 @@ func buildAndMarshalPublicationEvent(p *videoPayload, contentURI, lastModified, 
 		return producer.Message{}, err
 	}
 
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		logger.WithError(err).Warn("Failed to generate UUID")
+		return producer.Message{}, err
+	}
+
 	headers := map[string]string{
 		"X-Request-Id":      pubRef,
 		"Message-Timestamp": lastModified,
-		"Message-Id":        uuid.NewV4().String(),
+		"Message-Id":        uuid.String(),
 		"Message-Type":      "cms-content-published",
 		"Content-Type":      "application/json",
 		"Origin-System-Id":  videoSystemOrigin,


### PR DESCRIPTION
## What

The video mapper's build steps are failing because satori's uuid module is depricated and thus snyk scan fails.
It should be replaced with a new compatible uuid module

## Why
[Jira Ticket](https://financialtimes.atlassian.net/browse/UPPSF-2695)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)
