### PR TITLE
Adding deleted field to delete payloads

### DIFF
--- a/video/model.go
+++ b/video/model.go
@@ -50,6 +50,7 @@ type videoPayload struct {
 	CanonicalWebURL       string                  `json:"canonicalWebUrl,omitempty"`
 	AlternativeTitles     *alternativeTitles      `json:"alternativeTitles,omitempty"`
 	AlternativeStandfirst *alternativeStandfirsts `json:"alternativeStandfirsts,omitempty"`
+	Deleted               bool                    `json:"deleted,omitempty"`
 }
 
 type caption struct {

--- a/video/video_mapper.go
+++ b/video/video_mapper.go
@@ -65,7 +65,12 @@ func (v VideoMapper) TransformMsg(m kafka.FTMessage) (kafka.FTMessage, string, e
 		}
 
 		contentURI := utils.GetPrefixedURL(videoContentURIBase, uuid)
-		videoModel := &videoPayload{}
+
+		videoModel := &videoPayload{
+			ID:      uuid,
+			Deleted: true,
+		}
+
 		deleteVideoMsg, err := v.buildAndMarshalPublicationEvent(videoModel, contentURI, lastModified, tid)
 		return deleteVideoMsg, uuid, err
 	}

--- a/video/video_mapper_test.go
+++ b/video/video_mapper_test.go
@@ -92,7 +92,7 @@ func TestTransformMsg_UnpublishEvent(t *testing.T) {
 	resultMsg, uuid, err := mapper.TransformMsg(message)
 	assert.NoError(t, err, "Error not expected for unpublish event")
 	assert.Equal(t, "bad50c54-76d9-30e9-8734-b999c708aa4c", uuid, "UUID not extracted correctly from unpublish event")
-	assert.Equal(t, "{\"contentUri\":\"http://next-video-mapper.svc.ft.com/video/model/bad50c54-76d9-30e9-8734-b999c708aa4c\",\"payload\":{},\"lastModified\":\"2017-04-13T10:27:32.353Z\"}", resultMsg.Body)
+	assert.Equal(t, "{\"contentUri\":\"http://next-video-mapper.svc.ft.com/video/model/bad50c54-76d9-30e9-8734-b999c708aa4c\",\"payload\":{\"uuid\":\"bad50c54-76d9-30e9-8734-b999c708aa4c\",\"deleted\":true},\"lastModified\":\"2017-04-13T10:27:32.353Z\"}", resultMsg.Body)
 }
 
 func TestTransformMsg_Success(t *testing.T) {


### PR DESCRIPTION
# Description

## What

Adding a `deleted` and `uuid` fields to the payloads of unpublish messages. `publishReference` does not seem to be needed. You can see the expected format in [post-publication-combiner's model here](https://github.com/Financial-Times/post-publication-combiner/blob/master/processor/model.go). 

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3513

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
